### PR TITLE
Switch to KLUFactorization for the solver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ profiles.hdf5
 *.mp4
 *.gif
 docs/build
+alloc-profile.pb.gz
 
 NuclearBurning.md

--- a/examples/NuclearBurning.jl
+++ b/examples/NuclearBurning.jl
@@ -73,7 +73,7 @@ using LinearSolve
     corr = solve($sm.linear_solver)
 end
 #=
-On my system, this takes on the order of 4.3 ms. Next up we can check how long it takes to compute a single row of the
+On my system, this takes on the order of 800 μs. Next up we can check how long it takes to compute a single row of the
 jacobian. With a row here I mean all the entries that correspond to one cell. The code below benchmarks the time it
 takes to compute the jacobian elements associated with row 2
 =#

--- a/src/Evolution/StellarModel.jl
+++ b/src/Evolution/StellarModel.jl
@@ -100,7 +100,8 @@ function StellarModel(varnames::Vector{Symbol},
                       nspecies::Int,
                       nz::Int,
                       eos::AbstractEOS,
-                      opacity::AbstractOpacity)
+                      opacity::AbstractOpacity;
+                      solver_method = KLUFactorization())
     ind_vars = ones(nvars * nz)
     eqs = ones(nvars * nz)
     m = ones(nz)
@@ -113,7 +114,7 @@ function StellarModel(varnames::Vector{Symbol},
     jacobian = sparse(jac_BBM)
     #create solver
     problem = LinearProblem(jacobian, eqs)
-    linear_solver = init(problem)
+    linear_solver = init(problem, solver_method)
 
     isotope_data = Chem.get_isotope_list()
 


### PR DESCRIPTION
Small change that reduces runtime of NuclearBurning.jl by ~16% on my computer. It also reduces allocation size of the evolution loop in that example by ~10%.