### PR TITLE
made isotope_list a global

### DIFF
--- a/examples/example_options.toml
+++ b/examples/example_options.toml
@@ -1,13 +1,13 @@
-    [solver]
-    newton_max_iter_first_step = 1000
-    newton_max_iter = 200
+[solver]
+newton_max_iter_first_step = 1000
+newton_max_iter = 200
 
-    [timestep]
-    dt_max_increase = 2.0
+[timestep]
+dt_max_increase = 2.0
 
-    [termination]
-    max_model_number = 3000
-    max_center_T = 4e7
+[termination]
+max_model_number = 3000
+max_center_T = 4e7
 
-    [io]
-    profile_interval = 50
+[io]
+profile_interval = 50

--- a/src/Chem/Chem.jl
+++ b/src/Chem/Chem.jl
@@ -54,4 +54,6 @@ function get_isotope_list()
     return isotope_list
 end
 
+global isotope_list::Dict{Symbol,Isotope} = get_isotope_list()
+
 end # module Stellar

--- a/src/EOS/IdealEOS.jl
+++ b/src/EOS/IdealEOS.jl
@@ -10,34 +10,33 @@ struct IdealEOS <: AbstractEOS
 end
 
 """
-    get_μ_IdealEOS(isotope_data, xa, species)
+    get_μ_IdealEOS(xa, species)
 
-computes the molecular weight of the mixture `xa`, given the `isotope_data` and list of `species`.
+computes the molecular weight of the mixture `xa`, given and list of `species`.
 """
-function get_μ_IdealEOS(isotope_data::Dict{Symbol,Isotope}, xa::Vector{<:TT},
-                        species::Vector{Symbol})::TT where {TT<:Real}
+function get_μ_IdealEOS(xa::Vector{<:TT}, species::Vector{Symbol})::TT where {TT<:Real}
     # See section 4.2 of Kipp
     μ::TT = 0
     for i in eachindex(species)
         # assumes complete ionization!
-        μ += xa[i] * (1 + isotope_data[species[i]].Z) / isotope_data[species[i]].mass
+        μ += xa[i] * (1 + Chem.isotope_list[species[i]].Z) / Chem.isotope_list[species[i]].mass
     end
     return 1 / μ
 end
 
 """
-    get_EOS_resultsTP(eos, isotope_data, lnT, lnP, xa, species)
+    get_EOS_resultsTP(eos, lnT, lnP, xa, species)
 
 computes thermodynamical quantities of a mixture `xa` at temperature `lnT` and pressure `lnP`, given the ideal equation
-of state `eos`, `isotope_data` and list of `species`.
+of state `eos`, list of `species`.
 """
-function get_EOS_resultsTP(eos::IdealEOS, isotope_data::Dict{Symbol,Isotope}, lnT::TT, lnP::TT, xa::Vector{<:TT},
+function get_EOS_resultsTP(eos::IdealEOS, lnT::TT, lnP::TT, xa::Vector{<:TT},
                            species::Vector{Symbol})::Vector{<:TT} where {TT<:Real}
     # See section 13.2 of Kipp
     β::TT = 1
     T = exp(lnT)
     P = exp(lnP)
-    μ = get_μ_IdealEOS(isotope_data, xa, species)
+    μ = get_μ_IdealEOS(xa, species)
     Prad = CRAD * T^4 / 3
     ρ = μ / (CGAS * T) * (P - Prad)
 

--- a/src/Evolution/Equations.jl
+++ b/src/Evolution/Equations.jl
@@ -104,12 +104,12 @@ function equationH1(sm, k,
     ρ₀ = eos00[1]
     ϵnuc = 0.1 * var00[sm.vari[:H1]]^2 * ρ₀ * (exp(var00[sm.vari[:lnT]]) / 1e6)^4 +
            0.1 * var00[sm.vari[:H1]] * ρ₀ * (exp(var00[sm.vari[:lnT]]) / 1e7)^18
-    rate_per_unit_mass = 4 * ϵnuc / ((4 * isotope_list[:H1].mass - isotope_list[:He4].mass) * AMU * CLIGHT^2)
+    rate_per_unit_mass = 4 * ϵnuc / ((4 * Chem.isotope_list[:H1].mass - Chem.isotope_list[:He4].mass) * AMU * CLIGHT^2)
 
     Xi = sm.ssi.ind_vars[(k - 1) * sm.nvars + sm.vari[:H1]]
 
     return (var00[sm.vari[:H1]] - Xi) / sm.ssi.dt +
-           isotope_list[:H1].mass * AMU * rate_per_unit_mass
+           Chem.isotope_list[:H1].mass * AMU * rate_per_unit_mass
 end
 
 function equationHe4(sm, k,

--- a/src/Evolution/EvolutionLoop.jl
+++ b/src/Evolution/EvolutionLoop.jl
@@ -22,7 +22,7 @@ function set_end_step_info!(sm::StellarModel)
         species_names = sm.varnames[(sm.nvars - sm.nspecies + 1):end]
         xa = sm.ind_vars[(i * sm.nvars - sm.nspecies + 1):(i * sm.nvars)]
 
-        eos = get_EOS_resultsTP(sm.eos, sm.isotope_data, sm.psi.lnT[i], sm.psi.lnP[i], xa, species_names)
+        eos = get_EOS_resultsTP(sm.eos, sm.psi.lnT[i], sm.psi.lnP[i], xa, species_names)
 
         sm.esi.lnρ[i] = log(eos[1])
         sm.esi.ind_vars[((i - 1) * sm.nvars + 1):(i * sm.nvars)] .= sm.ind_vars[((i - 1) * sm.nvars + 1):(i * sm.nvars)]

--- a/src/Evolution/IO.jl
+++ b/src/Evolution/IO.jl
@@ -61,7 +61,7 @@ function get_eos_for_cell(sm::StellarModel, k::Int)
     lnP = sm.esi.lnP[k]
     species_names = sm.varnames[(sm.nvars - sm.nspecies + 1):end]
     xa = sm.ind_vars[(k * sm.nvars - sm.nspecies + 1):(k * sm.nvars)]
-    return get_EOS_resultsTP(sm.eos, sm.isotope_data, lnT, lnP, xa, species_names)
+    return get_EOS_resultsTP(sm.eos, lnT, lnP, xa, species_names)
 end
 
 profile_output_options = Dict(

--- a/src/Evolution/InitialCondition.jl
+++ b/src/Evolution/InitialCondition.jl
@@ -2,8 +2,6 @@
 using ForwardDiff
 using Roots
 
-isotope_list = Chem.get_isotope_list()
-
 function theta_n(xi)
     return sin(xi) / xi
 end

--- a/src/Evolution/Solver.jl
+++ b/src/Evolution/Solver.jl
@@ -32,20 +32,20 @@ function eval_cell_eqs(sm::StellarModel, k::Int, ind_vars_view::Vector{<:TT}) wh
     end
 
     # collect eos and κ info (could be sped up by doing this before eval. the Jacobian!)
-    eos00 = get_EOS_resultsTP(sm.eos, sm.isotope_data, var00[sm.vari[:lnT]], var00[sm.vari[:lnP]],
+    eos00 = get_EOS_resultsTP(sm.eos, var00[sm.vari[:lnT]], var00[sm.vari[:lnP]],
                               var00[(sm.nvars - sm.nspecies + 1):(sm.nvars)], species_names)
-    κ00 = get_opacity_resultsTP(sm.opacity, sm.isotope_data, var00[sm.vari[:lnT]], var00[sm.vari[:lnP]],
+    κ00 = get_opacity_resultsTP(sm.opacity, var00[sm.vari[:lnT]], var00[sm.vari[:lnP]],
                                 var00[(sm.nvars - sm.nspecies + 1):(sm.nvars)], species_names)
     if k != 1
-        eosm1 = get_EOS_resultsTP(sm.eos, sm.isotope_data, varm1[sm.vari[:lnT]], varm1[sm.vari[:lnP]],
+        eosm1 = get_EOS_resultsTP(sm.eos, varm1[sm.vari[:lnT]], varm1[sm.vari[:lnP]],
                                   varm1[(sm.nvars - sm.nspecies + 1):(sm.nvars)], species_names)
-        κm1 = get_opacity_resultsTP(sm.opacity, sm.isotope_data, varm1[sm.vari[:lnT]], varm1[sm.vari[:lnP]],
+        κm1 = get_opacity_resultsTP(sm.opacity, varm1[sm.vari[:lnT]], varm1[sm.vari[:lnP]],
                                     varm1[(sm.nvars - sm.nspecies + 1):(sm.nvars)], species_names)
     end
     if k != sm.nz
-        eosp1 = get_EOS_resultsTP(sm.eos, sm.isotope_data, varp1[sm.vari[:lnT]], varp1[sm.vari[:lnP]],
+        eosp1 = get_EOS_resultsTP(sm.eos, varp1[sm.vari[:lnT]], varp1[sm.vari[:lnP]],
                                   varp1[(sm.nvars - sm.nspecies + 1):(sm.nvars)], species_names)
-        κp1 = get_opacity_resultsTP(sm.opacity, sm.isotope_data, varp1[sm.vari[:lnT]], varp1[sm.vari[:lnP]],
+        κp1 = get_opacity_resultsTP(sm.opacity, varp1[sm.vari[:lnT]], varp1[sm.vari[:lnP]],
                                     varp1[(sm.nvars - sm.nspecies + 1):(sm.nvars)], species_names)
     end
 

--- a/src/Evolution/StellarModel.jl
+++ b/src/Evolution/StellarModel.jl
@@ -69,7 +69,6 @@ The struct has two parametric types, `T1` for 'normal' numbers, `T2` for dual nu
     # Some basic info
     eos::EOS.AbstractEOS
     opacity::Opacity.AbstractOpacity
-    isotope_data::Dict{Symbol,Isotope}
 
     # Jacobian matrix
     jacobian::SparseMatrixCSC{T1,Int64}
@@ -114,8 +113,6 @@ function StellarModel(varnames::Vector{Symbol}, structure_equations::Vector{Func
     problem = LinearProblem(jacobian, eqs)
     linear_solver = init(problem, solver_method)
 
-    isotope_data = Chem.get_isotope_list()
-
     vari::Dict{Symbol,Int} = Dict()
     for i in eachindex(varnames)
         vari[varnames[i]] = i
@@ -138,6 +135,6 @@ function StellarModel(varnames::Vector{Symbol}, structure_equations::Vector{Func
 
     StellarModel(ind_vars=ind_vars, varnames=varnames, eqs=eqs, nvars=nvars, nspecies=nspecies,
                  structure_equations=structure_equations, vari=vari, nz=nz, m=m, dm=dm, mstar=0.0, time=0.0, dt=0.0,
-                 model_number=0, eos=eos, opacity=opacity, isotope_data=isotope_data, jacobian=jacobian,
+                 model_number=0, eos=eos, opacity=opacity, jacobian=jacobian,
                  linear_solver=linear_solver, psi=psi, ssi=ssi, esi=esi, opt=opt)
 end

--- a/src/Opacity/SimpleElectronScattering.jl
+++ b/src/Opacity/SimpleElectronScattering.jl
@@ -3,23 +3,14 @@ export get_opacity_resultsTP
 struct SimpleElectronScatteringOpacity <: AbstractOpacity end
 
 """
-    get_opacity_resultsTP(opacity::SimpleElectronScatteringOpacity,
-                               isotope_data::Dict{Symbol,Isotope},
-                               lnT::TT,
-                               lnP::TT,
-                               xa::Vector{<:TT},
-                               species::Vector{Symbol})::TT where {TT<:Real}
+    get_opacity_resultsTP(opacity::SimpleElectronScatteringOpacity, lnT::TT, lnP::TT, xa::Vector{<:TT},
+                            species::Vector{Symbol})::TT where {TT<:Real}
 
-Evaluates the opacity of the current mixture with mass fractions `xa`, species symbols
-`species` (both these should be of length `nspecies`), the natural log of temperature
-and pressure `lnT`, `lnP`, the opacity law `opacity` and the `isotope_data` dictionary.
+Evaluates the opacity of the current mixture with mass fractions `xa`, species symbols `species` (both these should be
+of length `nspecies`), the natural log of temperature and pressure `lnT`, `lnP`, and the opacity law `opacity`.
 """
-function get_opacity_resultsTP(opacity::SimpleElectronScatteringOpacity,
-                               isotope_data::Dict{Symbol,Isotope},
-                               lnT::TT,
-                               lnP::TT,
-                               xa::Vector{<:TT},
+function get_opacity_resultsTP(opacity::SimpleElectronScatteringOpacity, lnT::TT, lnP::TT, xa::Vector{<:TT},
                                species::Vector{Symbol})::TT where {TT<:Real}
     iH1 = findfirst(==(:H1), species)
-    return 0.2 * (1 + xa[iH1]) # in cm^2/g
+    return 0.2 * (1 + xa[iH1])  # in cm^2/g
 end


### PR DESCRIPTION
On my machine, a run of `NuclearBurning.jl` gives 103GiB of allocations, instead of 109GiB, so a tiny bit better with just this minimal change