### PR TITLE
Use mutating equations

### DIFF
--- a/examples/NuclearBurning.jl
+++ b/examples/NuclearBurning.jl
@@ -26,8 +26,8 @@ to $\kappa=0.2(1+X)\;[\mathrm{cm^2\;g^{-1}}]$ is available.
 nvars = 6
 nspecies = 2
 varnames = [:lnP, :lnT, :lnr, :lum, :H1, :He4]
-structure_equations = [Evolution.equationHSE, Evolution.equationT, Evolution.equationContinuity,
-                       Evolution.equationLuminosity, Evolution.equationH1, Evolution.equationHe4]
+structure_equations = [Evolution.equationHSE!, Evolution.equationT!, Evolution.equationContinuity!,
+                       Evolution.equationLuminosity!, Evolution.equationH1!, Evolution.equationHe4!]
 nz = 1000
 eos = EOS.IdealEOS(false)
 opacity = Opacity.SimpleElectronScatteringOpacity()

--- a/src/EOS/IdealEOS.jl
+++ b/src/EOS/IdealEOS.jl
@@ -14,7 +14,7 @@ end
 
 computes the molecular weight of the mixture `xa`, given and list of `species`.
 """
-function get_μ_IdealEOS(xa::Vector{<:TT}, species::Vector{Symbol})::TT where {TT<:Real}
+function get_μ_IdealEOS(xa::AbstractVector{TT}, species::Vector{Symbol})::TT where {TT<:Real}
     # See section 4.2 of Kipp
     μ::TT = 0
     for i in eachindex(species)
@@ -30,8 +30,8 @@ end
 computes thermodynamical quantities of a mixture `xa` at temperature `lnT` and pressure `lnP`, given the ideal equation
 of state `eos`, list of `species`.
 """
-function get_EOS_resultsTP(eos::IdealEOS, lnT::TT, lnP::TT, xa::Vector{<:TT},
-                           species::Vector{Symbol})::Vector{<:TT} where {TT<:Real}
+function get_EOS_resultsTP(eos::IdealEOS, lnT::TT, lnP::TT, xa::AbstractVector{TT},
+                           species::Vector{Symbol})::Vector{TT} where {TT<:Real}
     # See section 13.2 of Kipp
     β::TT = 1
     T = exp(lnT)

--- a/src/Evolution/Equations.jl
+++ b/src/Evolution/Equations.jl
@@ -1,12 +1,12 @@
-function equationHSE!(results::AbstractVector{TT}, sm::StellarModel, k::Int,
-                     varm1::AbstractVector{TT}, var00::AbstractVector{TT}, varp1::AbstractVector{TT},
-                     eosm1::AbstractVector{TT}, eos00::AbstractVector{TT}, eosp1::AbstractVector{TT},
-                     κm1::TT, κ00::TT, κp1::TT) where {TT<:Real}
+function equationHSE!(results::Matrix{TT}, sm::StellarModel, k::Int, i::Int,
+                      varm1::AbstractVector{TT}, var00::AbstractVector{TT}, varp1::AbstractVector{TT},
+                      eosm1::AbstractVector{TT}, eos00::AbstractVector{TT}, eosp1::AbstractVector{TT},
+                      κm1::TT, κ00::TT, κp1::TT) where {TT<:Real}
     if k == sm.nz  # atmosphere boundary condition
         lnP₀ = var00[sm.vari[:lnP]]
         r₀ = exp(var00[sm.vari[:lnr]])
         g₀ = CGRAV * sm.mstar / r₀^2
-        results[k] = lnP₀ - log(2g₀ / (3κ00))  # Eddington gray, ignoring radiation pressure term
+        results[k, i] = lnP₀ - log(2g₀ / (3κ00))  # Eddington gray, ignoring radiation pressure term
         return
     end
     lnP₊ = varp1[sm.vari[:lnP]]
@@ -15,19 +15,20 @@ function equationHSE!(results::AbstractVector{TT}, sm::StellarModel, k::Int,
     r₀ = exp(var00[sm.vari[:lnr]])
     dm = (sm.m[k + 1] - sm.m[k])
 
-    results[k] = (exp(lnPface) * (lnP₊ - lnP₀) / dm + CGRAV * sm.m[k] / (4π * r₀^4)) /
-           (CGRAV * sm.m[k] / (4π * r₀^4))
+    results[k, i] = (exp(lnPface) * (lnP₊ - lnP₀) / dm + CGRAV * sm.m[k] / (4π * r₀^4)) /
+                (CGRAV * sm.m[k] / (4π * r₀^4))
+    return
 end
 
-function equationT!(results::AbstractVector{TT}, sm::StellarModel, k::Int,
-                   varm1::AbstractVector{TT}, var00::AbstractVector{TT}, varp1::AbstractVector{TT},
-                   eosm1::AbstractVector{TT}, eos00::AbstractVector{TT}, eosp1::AbstractVector{TT},
-                   κm1::TT, κ00::TT, κp1::TT) where {TT<:Real}
+function equationT!(results::Matrix{TT}, sm::StellarModel, k::Int, i::Int,
+                    varm1::AbstractVector{TT}, var00::AbstractVector{TT}, varp1::AbstractVector{TT},
+                    eosm1::AbstractVector{TT}, eos00::AbstractVector{TT}, eosp1::AbstractVector{TT},
+                    κm1::TT, κ00::TT, κp1::TT) where {TT<:Real}
     if k == sm.nz  # atmosphere boundary condition
         lnT₀ = var00[sm.vari[:lnT]]
         L₀ = var00[sm.vari[:lum]] * LSUN
         r₀ = exp(var00[sm.vari[:lnr]])
-        results[k] = lnT₀ - log(L₀ / (BOLTZ_SIGMA * 4π * r₀^2)) / 4  # Eddington gray, ignoring radiation pressure term
+        results[k, i] = lnT₀ - log(L₀ / (BOLTZ_SIGMA * 4π * r₀^2)) / 4  # Eddington gray, ignoring radiation pressure term
         return
     end
     κface = exp((sm.dm[k] * log(κ00) + sm.dm[k + 1] * log(κp1)) / (sm.dm[k] + sm.dm[k + 1]))
@@ -43,21 +44,25 @@ function equationT!(results::AbstractVector{TT}, sm::StellarModel, k::Int,
     ∇ₐ = (sm.dm[k] * eos00[7] + sm.dm[k + 1] * eosp1[7]) / (sm.dm[k] + sm.dm[k + 1])
 
     if (∇ᵣ < ∇ₐ)
-        results[k] = (Tface * (lnT₊ - lnT₀) / sm.dm[k] +
-                CGRAV * sm.m[k] * Tface / (4π * r₀^4 * Pface) * ∇ᵣ) / (CGRAV * sm.m[k] * Tface / (4π * r₀^4 * Pface))  # only radiative transport
+        results[k, i] = (Tface * (lnT₊ - lnT₀) / sm.dm[k] +
+                     CGRAV * sm.m[k] * Tface / (4π * r₀^4 * Pface) * ∇ᵣ) /
+                    (CGRAV * sm.m[k] * Tface / (4π * r₀^4 * Pface))  # only radiative transport
     else  # should do convection here
-        results[k] = (Tface * (lnT₊ - lnT₀) / sm.dm[k] +
-                CGRAV * sm.m[k] * Tface / (4π * r₀^4 * Pface) * ∇ₐ) / (CGRAV * sm.m[k] * Tface / (4π * r₀^4 * Pface))  # only radiative transport
+        results[k, i] = (Tface * (lnT₊ - lnT₀) / sm.dm[k] +
+                     CGRAV * sm.m[k] * Tface / (4π * r₀^4 * Pface) * ∇ₐ) /
+                    (CGRAV * sm.m[k] * Tface / (4π * r₀^4 * Pface))  # only radiative transport
     end
+    return
 end
 
-function equationLuminosity!(results::AbstractVector{TT}, sm::StellarModel, k::Int,
-                            varm1::AbstractVector{TT}, var00::AbstractVector{TT}, varp1::AbstractVector{TT},
-                            eosm1::AbstractVector{TT}, eos00::AbstractVector{TT}, eosp1::AbstractVector{TT},
-                            κm1::TT, κ00::TT, κp1::TT) where {TT<:Real}
-    L₋::TT = 0  # central luminosity is zero at first cell
+function equationLuminosity!(results::Matrix{TT}, sm::StellarModel, k::Int, i::Int,
+                             varm1::AbstractVector{TT}, var00::AbstractVector{TT}, varp1::AbstractVector{TT},
+                             eosm1::AbstractVector{TT}, eos00::AbstractVector{TT}, eosp1::AbstractVector{TT},
+                             κm1::TT, κ00::TT, κp1::TT) where {TT<:Real}
     if k > 1
         L₋ = varm1[sm.vari[:lum]] * LSUN  # change it if not at first cell
+    else
+        L₋::TT = 0  # central luminosity is zero at first cell
     end
     L₀ = var00[sm.vari[:lum]] * LSUN
     ρ₀ = eos00[1]
@@ -69,18 +74,20 @@ function equationLuminosity!(results::AbstractVector{TT}, sm::StellarModel, k::I
     ϵnuc = 0.1 * var00[sm.vari[:H1]]^2 * ρ₀ * (exp(var00[sm.vari[:lnT]]) / 1e6)^4 +
            0.1 * var00[sm.vari[:H1]] * ρ₀ * (exp(var00[sm.vari[:lnT]]) / 1e7)^18
 
-    results[k] = ((L₀ - L₋) / sm.dm[k] - ϵnuc + cₚ * dTdt - (δ / ρ₀) * dPdt)  # no neutrinos
+    results[k, i] = ((L₀ - L₋) / sm.dm[k] - ϵnuc + cₚ * dTdt - (δ / ρ₀) * dPdt)  # no neutrinos
+    return
 end
 
-function equationContinuity!(results::AbstractVector{TT}, sm::StellarModel, k::Int,
-                            varm1::AbstractVector{TT}, var00::AbstractVector{TT}, varp1::AbstractVector{TT},
-                            eosm1::AbstractVector{TT}, eos00::AbstractVector{TT}, eosp1::AbstractVector{TT},
-                            κm1::TT, κ00::TT, κp1::TT) where {TT<:Real}
+function equationContinuity!(results::Matrix{TT}, sm::StellarModel, k::Int, i::Int,
+                             varm1::AbstractVector{TT}, var00::AbstractVector{TT}, varp1::AbstractVector{TT},
+                             eosm1::AbstractVector{TT}, eos00::AbstractVector{TT}, eosp1::AbstractVector{TT},
+                             κm1::TT, κ00::TT, κp1::TT) where {TT<:Real}
     ρ₀ = eos00[1]
     r₀ = exp(var00[sm.vari[:lnr]])
-    r₋::TT = 0  # central radius is zero at first cell
     if k > 1
         r₋ = exp(varm1[sm.vari[:lnr]])  # change it if not at first cell
+    else
+        r₋::TT = 0  # central radius is zero at first cell
     end
 
     dm = sm.m[k]  # this is only valid for k=1
@@ -92,16 +99,17 @@ function equationContinuity!(results::AbstractVector{TT}, sm::StellarModel, k::I
     expected_dr³_dm = 3 / (4π * ρ₀)
     actual_dr³_dm = (r₀^3 - r₋^3) / dm
 
-    results[k] = (expected_dr³_dm - actual_dr³_dm) * ρ₀
+    results[k, i] = (expected_dr³_dm - actual_dr³_dm) * ρ₀
+    return
 end
 
 # To test performance, include 8 isotopes similar to basic.net in MESA.
 # of course we are keeping these fixed now, but it lets us test their impact on the
 # computation of the jacobian
-function equationH1!(results::AbstractVector{TT}, sm::StellarModel, k::Int,
-                    varm1::AbstractVector{TT}, var00::AbstractVector{TT}, varp1::AbstractVector{TT},
-                    eosm1::AbstractVector{TT}, eos00::AbstractVector{TT}, eosp1::AbstractVector{TT},
-                    κm1::TT, κ00::TT, κp1::TT)::TT where {TT<:Real}
+function equationH1!(results::Matrix{TT}, sm::StellarModel, k::Int, i::Int,
+                     varm1::AbstractVector{TT}, var00::AbstractVector{TT}, varp1::AbstractVector{TT},
+                     eosm1::AbstractVector{TT}, eos00::AbstractVector{TT}, eosp1::AbstractVector{TT},
+                     κm1::TT, κ00::TT, κp1::TT) where {TT<:Real}
     ρ₀ = eos00[1]
     ϵnuc = 0.1 * var00[sm.vari[:H1]]^2 * ρ₀ * (exp(var00[sm.vari[:lnT]]) / 1e6)^4 +
            0.1 * var00[sm.vari[:H1]] * ρ₀ * (exp(var00[sm.vari[:lnT]]) / 1e7)^18
@@ -109,13 +117,15 @@ function equationH1!(results::AbstractVector{TT}, sm::StellarModel, k::Int,
 
     Xi = sm.ssi.ind_vars[(k - 1) * sm.nvars + sm.vari[:H1]]
 
-    results[k] = (var00[sm.vari[:H1]] - Xi) / sm.ssi.dt +
-           Chem.isotope_list[:H1].mass * AMU * rate_per_unit_mass
+    results[k, i] = (var00[sm.vari[:H1]] - Xi) / sm.ssi.dt +
+                Chem.isotope_list[:H1].mass * AMU * rate_per_unit_mass
+    return
 end
 
-function equationHe4!(results::AbstractVector{TT}, sm::StellarModel, k::Int,
-                     varm1::AbstractVector{TT}, var00::AbstractVector{TT}, varp1::AbstractVector{TT},
-                     eosm1::AbstractVector{TT}, eos00::AbstractVector{TT}, eosp1::AbstractVector{TT},
-                     κm1::TT, κ00::TT, κp1::TT)::TT where {TT<:Real}
-    results[k] = var00[sm.vari[:He4]] + var00[sm.vari[:H1]] - 1.0
+function equationHe4!(results::Matrix{TT}, sm::StellarModel, k::Int, i::Int,
+                      varm1::AbstractVector{TT}, var00::AbstractVector{TT}, varp1::AbstractVector{TT},
+                      eosm1::AbstractVector{TT}, eos00::AbstractVector{TT}, eosp1::AbstractVector{TT},
+                      κm1::TT, κ00::TT, κp1::TT) where {TT<:Real}
+    results[k, i] = var00[sm.vari[:He4]] + var00[sm.vari[:H1]] - 1.0
+    return
 end

--- a/src/Evolution/Evaluation.jl
+++ b/src/Evolution/Evaluation.jl
@@ -40,7 +40,7 @@ function eval_cell_eqs!(sm::StellarModel, k::Int)
 
     # evaluate all equations!
     for i = 1:(sm.nvars)
-        sm.eqs_duals[k, i] = sm.structure_equations[i](sm, k, varm1, var00, varp1, eosm1, eos00, eosp1, κm1, κ00, κp1)
+        sm.structure_equations[i](view(sm.eqs_duals, :, i), sm, k, varm1, var00, varp1, eosm1, eos00, eosp1, κm1, κ00, κp1)
     end
 end
 

--- a/src/Evolution/Evaluation.jl
+++ b/src/Evolution/Evaluation.jl
@@ -6,17 +6,17 @@ variables, `ind_vars_view`.
 """
 function eval_cell_eqs!(sm::StellarModel, k::Int)
 
-    var00 = get_tmp(sm.diff_caches[k, :][2], sm.eqs_duals[k, 1])
+    var00 = get_tmp(view(sm.diff_caches, k, :)[2], sm.eqs_duals[k, 1])
     eos00 = get_EOS_resultsTP(sm.eos, var00[sm.vari[:lnT]], var00[sm.vari[:lnP]],
-                              var00[(sm.nvars - sm.nspecies + 1):(sm.nvars)], sm.species_names)
+                              view(var00, (sm.nvars - sm.nspecies + 1):(sm.nvars)), sm.species_names)
     κ00 = get_opacity_resultsTP(sm.opacity, var00[sm.vari[:lnT]], var00[sm.vari[:lnP]],
-                                var00[(sm.nvars - sm.nspecies + 1):(sm.nvars)], sm.species_names)
+                                view(var00, (sm.nvars - sm.nspecies + 1):(sm.nvars)), sm.species_names)
     if k != 1
-        varm1 = get_tmp(sm.diff_caches[k, :][1], sm.eqs_duals[k, 1])
+        varm1 = get_tmp(view(sm.diff_caches, k, :)[1], sm.eqs_duals[k, 1])
         eosm1 = get_EOS_resultsTP(sm.eos, varm1[sm.vari[:lnT]], varm1[sm.vari[:lnP]],
-                                  varm1[(sm.nvars - sm.nspecies + 1):(sm.nvars)], sm.species_names)
+                                  view(varm1, (sm.nvars - sm.nspecies + 1):(sm.nvars)), sm.species_names)
         κm1 = get_opacity_resultsTP(sm.opacity, varm1[sm.vari[:lnT]], varm1[sm.vari[:lnP]],
-                                    varm1[(sm.nvars - sm.nspecies + 1):(sm.nvars)], sm.species_names)
+                                    view(varm1,(sm.nvars - sm.nspecies + 1):(sm.nvars)), sm.species_names)
     else
         varm1 = Vector{eltype(var00)}(undef, length(var00[1]))
         fill!(varm1, eltype(var00)(NaN))
@@ -25,11 +25,11 @@ function eval_cell_eqs!(sm::StellarModel, k::Int)
         κm1 = typeof(κ00)(NaN)
     end
     if k != sm.nz
-        varp1 = get_tmp(sm.diff_caches[k, :][3], sm.eqs_duals[k, 1])
+        varp1 = get_tmp(view(sm.diff_caches, k, :)[3], sm.eqs_duals[k, 1])
         eosp1 = get_EOS_resultsTP(sm.eos, varp1[sm.vari[:lnT]], varp1[sm.vari[:lnP]],
-                                  varp1[(sm.nvars - sm.nspecies + 1):(sm.nvars)], sm.species_names)
+                                  view(varp1, (sm.nvars - sm.nspecies + 1):(sm.nvars)), sm.species_names)
         κp1 = get_opacity_resultsTP(sm.opacity, varp1[sm.vari[:lnT]], varp1[sm.vari[:lnP]],
-                                    varp1[(sm.nvars - sm.nspecies + 1):(sm.nvars)], sm.species_names)
+                                    view(varp1, (sm.nvars - sm.nspecies + 1):(sm.nvars)), sm.species_names)
     else
         varp1 = Vector{eltype(var00)}(undef, length(var00[1]))
         fill!(varp1, eltype(var00)(NaN))
@@ -40,7 +40,7 @@ function eval_cell_eqs!(sm::StellarModel, k::Int)
 
     # evaluate all equations!
     for i = 1:(sm.nvars)
-        sm.structure_equations[i](view(sm.eqs_duals, :, i), sm, k, varm1, var00, varp1, eosm1, eos00, eosp1, κm1, κ00, κp1)
+        sm.structure_equations[i](sm.eqs_duals, sm, k, i, varm1, var00, varp1, eosm1, eos00, eosp1, κm1, κ00, κp1)
     end
 end
 
@@ -67,7 +67,7 @@ function eval_jacobian_eqs_row!(sm::StellarModel, k::Int)
 
     Because this function acts on duals `eqs_duals`, we immediately evaluate the equations also.
     =#
-    set_diff_cache!(sm, k)  # set diff_caches to hold 1s where needed
+    init_diff_cache!(sm, k)  # set diff_caches to hold 1s where needed
     eval_cell_eqs!(sm, k)  # evaluate equations on the duals, so we have jacobian also
     if k == 1
         ki = sm.nvars * (k - 1) + 1
@@ -108,20 +108,36 @@ end
 """
     set_diff_cache!(sm::StellarModel, k::Int)
 
-Sets the diff_caches to the values of the independent variables
+Initializes the diff_caches to the values of the independent variables, and sets 1s in the correct spots where the
+dx_i^k/dx_i^k entries lie.
 """
-function set_diff_cache!(sm::StellarModel, k::Int)
+function init_diff_cache!(sm::StellarModel, k::Int)
+    # set all partials to 0 for the moment
+    sm.diff_caches[k, 1].dual_du[:] .= 0.0
+    sm.diff_caches[k, 2].dual_du[:] .= 0.0
+    sm.diff_caches[k, 3].dual_du[:] .= 0.0
+    #= these indices are headache inducing...
+    diff_caches[k, 2].dual_du has structure:
+    (x_1, dx_1^k/dx_1^k-1, ..., dx_1^k/dx_n^k-1, dx_1^k/dx_1^k, ..., dx_1^k/dx_n^k, dx_1^k/dx_1^k+1, ..., dx_1^k/dx_n^k+1,  # subsize 3*nvars+1
+     ...
+     x_n, dx_n^k/dx_1^k-1, ..., dx_n^k/dx_n^k-1, dx_n^k/dx_1^k, ..., dx_n^k/dx_n^k, dx_n^k/dx_1^k+1, ..., dx_n^k/dx_n^k+1)
+    diff_caches[k, 3].dual_du has numerators k -> k+1
+    diff_caches[k, 1].dual_du has numerators k -> k-1
+    =#
     for i = 1:(sm.nvars)
-        # set variable values in du and dual_du
+        # set variable values in du, dual_du and its corresponding non-zero derivative
         if k != 1
             sm.diff_caches[k, 1].du[i] = sm.ind_vars[sm.nvars * (k - 2) + i]
             sm.diff_caches[k, 1].dual_du[(i - 1) * (3 * sm.nvars + 1) + 1] = sm.ind_vars[sm.nvars * (k - 2) + i]
+            sm.diff_caches[k, 1].dual_du[(i - 1) * (3 * sm.nvars + 1) + 1 + i] = 1.0  # dx^k-1_i/dx^k-1_i = 1!!
         end
         sm.diff_caches[k, 2].du[i] = sm.ind_vars[sm.nvars * (k - 1) + i]
         sm.diff_caches[k, 2].dual_du[(i - 1) * (3 * sm.nvars + 1) + 1] = sm.ind_vars[sm.nvars * (k - 1) + i]
+        sm.diff_caches[k, 2].dual_du[(i - 1) * (3 * sm.nvars + 1) + 1 + sm.nvars + i] = 1.0  # dx^k_i/dx^k_i = 1!!
         if k != sm.nz
             sm.diff_caches[k, 3].du[i] = sm.ind_vars[sm.nvars * k + i]
             sm.diff_caches[k, 3].dual_du[(i - 1) * (3 * sm.nvars + 1) + 1] = sm.ind_vars[sm.nvars * k + i]
+            sm.diff_caches[k, 3].dual_du[(i - 1) * (3 * sm.nvars + 1) + 1 + 2 * sm.nvars + i] = 1.0  # dx^k+1_i/dx^k+1_i = 1!!
         end
     end
 end

--- a/src/Opacity/SimpleElectronScattering.jl
+++ b/src/Opacity/SimpleElectronScattering.jl
@@ -9,7 +9,7 @@ struct SimpleElectronScatteringOpacity <: AbstractOpacity end
 Evaluates the opacity of the current mixture with mass fractions `xa`, species symbols `species` (both these should be
 of length `nspecies`), the natural log of temperature and pressure `lnT`, `lnP`, and the opacity law `opacity`.
 """
-function get_opacity_resultsTP(opacity::SimpleElectronScatteringOpacity, lnT::TT, lnP::TT, xa::Vector{<:TT},
+function get_opacity_resultsTP(opacity::SimpleElectronScatteringOpacity, lnT::TT, lnP::TT, xa::AbstractVector{<:TT},
                                species::Vector{Symbol})::TT where {TT<:Real}
     iH1 = findfirst(==(:H1), species)
     return 0.2 * (1 + xa[iH1])  # in cm^2/g


### PR DESCRIPTION
Also includes smaller optimizations such as using views where appropriate.
Increases performance from 178M allocs, 41GiB, 25sec runtime of NuclearBurning.jl to 125M allocs, 29GiB, 22s runtime.